### PR TITLE
update Asterisk to 13.19

### DIFF
--- a/asterisk13.spec
+++ b/asterisk13.spec
@@ -7,7 +7,7 @@
 
 Summary: Asterisk, The Open Source PBX
 Name: asterisk13
-Version: 13.17.2
+Version: 13.19.1
 # reset release to 1 with each version bump
 Release: 3%{?dist}
 License: GPL
@@ -19,6 +19,7 @@ Patch3: voicemail-splitopts-odbcstorage.patch
 Patch4: voicemail-splitopts-imapstorage.patch
 Patch6: lazymembers.patch
 Patch8: ASTERISK-rb3984.patch
+Patch9: increase-max-stack.patch
 
 BuildRoot: %{_tmppath}/asterisk-%{version}-root
 URL: http://www.asterisk.org
@@ -573,6 +574,7 @@ cp apps/app_voicemail.exports.in apps/app_voicemail_imapstorage.exports.in
 %patch2 -p0
 %patch6 -p1
 %patch8 -p0
+%patch9 -p1
 
 %build
 %ifarch x86_64

--- a/asterisk13.spec
+++ b/asterisk13.spec
@@ -1242,11 +1242,7 @@ cd $RPM_BUILD_DIR
 %{_includedir}/asterisk/xml.h
 %{_includedir}/asterisk/xmldoc.h
 %{_includedir}/asterisk/doxygen/architecture.h
-%{_includedir}/asterisk/doxygen/asterisk-git-howto.h
-%{_includedir}/asterisk/doxygen/commits.h
 %{_includedir}/asterisk/doxygen/licensing.h
-%{_includedir}/asterisk/doxygen/releases.h
-%{_includedir}/asterisk/doxygen/reviewboard.h
 %{_includedir}/asterisk/celt.h
 %{_includedir}/asterisk/format.h
 %{_includedir}/asterisk/format_cap.h

--- a/increase-max-stack.patch
+++ b/increase-max-stack.patch
@@ -1,0 +1,26 @@
+diff --git a/include/asterisk/extconf.h b/include/asterisk/extconf.h
+index 1a04b01..4eaebb3 100644
+--- a/include/asterisk/extconf.h
++++ b/include/asterisk/extconf.h
+@@ -220,7 +220,7 @@ enum ext_match_t {
+ 	E_SPAWN =	0x12,	/* want to spawn an extension. Requires exact match */
+ 	E_FINDLABEL =	0x22	/* returns the priority for a given label. Requires exact match */
+ };
+-#define AST_PBX_MAX_STACK  128
++#define AST_PBX_MAX_STACK  512
+ 
+ /* request and result for pbx_find_extension */
+ struct pbx_find_info {
+diff --git a/include/asterisk/pbx.h b/include/asterisk/pbx.h
+index 770a1a9..8659eca 100644
+--- a/include/asterisk/pbx.h
++++ b/include/asterisk/pbx.h
+@@ -1548,7 +1548,7 @@ enum ext_match_t {
+ #define STATUS_NO_PRIORITY	3
+ #define STATUS_NO_LABEL		4
+ #define STATUS_SUCCESS		5
+-#define AST_PBX_MAX_STACK  128
++#define AST_PBX_MAX_STACK  512
+ 
+ /* request and result for pbx_find_extension */
+ struct pbx_find_info {

--- a/lazymembers.patch
+++ b/lazymembers.patch
@@ -1,33 +1,23 @@
-From c20eb93dbddf8e452de13ff7cce73f93680f1efd Mon Sep 17 00:00:00 2001
-From: Bryan Walters <bwalters@sangoma.com>
-Date: Wed, 13 Apr 2016 13:44:52 -0400
-Subject: [PATCH] Fix lazymembers patch for 13.8.0
-
----
- apps/app_queue.c | 121 +++++++++++++++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 118 insertions(+), 3 deletions(-)
-
-diff --git a/apps/app_queue.c b/apps/app_queue.c
-index 939a0e2..8fbd8c7 100644
---- a/apps/app_queue.c
-+++ b/apps/app_queue.c
+diff -ur asterisk-13.18.0/apps/app_queue.c asterisk-13.18.0.lazymembers/apps/app_queue.c
+--- asterisk-13.18.0/apps/app_queue.c	2017-10-30 15:33:07.000000000 +0000
++++ asterisk-13.18.0.lazymembers/apps/app_queue.c	2017-10-30 19:45:42.927723507 +0000
 @@ -1512,6 +1512,7 @@
  	int callcompletedinsl;               /*!< Whether the current call was completed within service level */
  	time_t starttime;                    /*!< The time at which the member answered the current caller. */
  	time_t lastcall;                     /*!< When last successful call was hungup */
-+        time_t lastnoanswer;                 /*!<When last dial attempt timed out */
++	time_t lastnoanswer;                 /*!<When last dial attempt timed out */
  	struct call_queue *lastqueue;	     /*!< Last queue we received a call */
  	unsigned int dead:1;                 /*!< Used to detect members deleted in realtime */
  	unsigned int delme:1;                /*!< Flag to delete entry on reload */
-@@ -1637,6 +1638,7 @@ struct call_queue {
+@@ -1641,6 +1642,7 @@
  	int weight;                         /*!< Respective weight */
  	int autopause;                      /*!< Auto pause queue members if they fail to answer */
  	int autopausedelay;                 /*!< Delay auto pause for autopausedelay seconds since last call */
 +	int LazyMembers;                    /*!< skip non-answering members for this many seconds */
  	int timeoutpriority;                /*!< Do we allow a fraction of the timeout to occur for a ring? */
-
+ 
  	/* Queue strategy things */
-@@ -2202,6 +2204,9 @@ static int get_member_status(struct call_queue *q, int max_penalty, int min_pena
+@@ -2207,6 +2209,9 @@
  				ast_debug(4, "%s is unavailable because his penalty is not between %d and %d\n", member->membername, min_penalty, max_penalty);
  				continue;
  			}
@@ -35,10 +25,10 @@ index 939a0e2..8fbd8c7 100644
 +                        //TODO: Add log message here
 +			continue;
  		}
-
+ 
  		switch (devstate ? ast_device_state(member->state_interface) : member->status) {
-@@ -2367,7 +2372,11 @@ static void device_state_cb(void *unused, struct stasis_subscription *sub, struc
-
+@@ -2448,7 +2453,11 @@
+ 
  			/* check every member until we find one NOT_INUSE */
  			if (!avail) {
 +				if (!(q->LazyMembers && m->lastnoanswer)) {
@@ -49,7 +39,7 @@ index 939a0e2..8fbd8c7 100644
  			}
  			if (avail && found_member) {
  				/* early exit as we've found an available member and the member of interest */
-@@ -3039,6 +3048,16 @@ static void queue_set_param(struct call_queue *q, const char *param, const char
+@@ -3131,6 +3140,16 @@
  		}
  	} else if (!strcasecmp(param, "autopause")) {
  		q->autopause = autopause2int(val);
@@ -66,20 +56,20 @@ index 939a0e2..8fbd8c7 100644
  	} else if (!strcasecmp(param, "autopausedelay")) {
  		q->autopausedelay = atoi(val);
  	} else if (!strcasecmp(param, "autopausebusy")) {
-@@ -4029,7 +4048,9 @@ static int num_available_members(struct call_queue *q)
+@@ -4138,7 +4157,9 @@
  	mem_iter = ao2_iterator_init(q->members, 0);
  	while ((mem = ao2_iterator_next(&mem_iter))) {
-
+ 
 +		if (!(q->LazyMembers && mem->lastnoanswer)) {
  		avl += is_member_available(q, mem);
 +		}
  		ao2_ref(mem, -1);
-
+ 
  		/* If autofill is not enabled or if the queue's strategy is ringall, then
-@@ -4178,6 +4199,10 @@ static int can_ring_entry(struct queue_ent *qe, struct callattempt *call)
+@@ -4247,6 +4268,10 @@
  		return 0;
  	}
-
+ 
 +	if (qe->parent->LazyMembers && call->member->lastnoanswer) {
 +                ast_log(LOG_DEBUG, "%s honoring LazyMembers\n", call->interface);
 +                return 0;
@@ -87,10 +77,10 @@ index 939a0e2..8fbd8c7 100644
  	if (use_weight && compare_weight(qe->parent, call->member)) {
  		ast_debug(1, "Priority queue delaying call to %s:%s\n",
  			qe->parent->name, call->interface);
-@@ -4535,6 +4560,20 @@ static void record_abandoned(struct queue_ent *qe)
+@@ -4623,6 +4648,20 @@
  	qe->parent->callsabandoned++;
  	ao2_unlock(qe->parent);
-
+ 
 +	/* Schmooze Update: Update our members if this is an abadoned call, to avoid issues with people being skipped in the queue */
 +        /* reset all the member lastnoanswer values */
 +        if (qe->parent->LazyMembers) {
@@ -107,8 +97,8 @@ index 939a0e2..8fbd8c7 100644
 +	/* End Schmooze Update */
  	ast_channel_publish_cached_blob(qe->chan, queue_caller_abandon_type(), blob);
  }
-
-@@ -4944,6 +4983,10 @@ static struct callattempt *wait_for_answer(struct queue_ent *qe, struct callatte
+ 
+@@ -5046,6 +5085,10 @@
  							endtime = (long) time(NULL);
  							endtime -= starttime;
  							rna(endtime * 1000, qe, o->chan, on, membername, qe->parent->autopausebusy);
@@ -119,7 +109,7 @@ index 939a0e2..8fbd8c7 100644
  							do_hang(o);
  							if (qe->parent->strategy != QUEUE_STRATEGY_RINGALL) {
  								if (qe->parent->timeoutrestart) {
-@@ -5155,6 +5198,10 @@ skip_frame:;
+@@ -5247,6 +5290,10 @@
  	if (!*to) {
  		for (o = start; o; o = o->call_next) {
  			if (o->chan) {
@@ -130,16 +120,16 @@ index 939a0e2..8fbd8c7 100644
  				rna(orig, qe, o->chan, o->interface, o->member->membername, 1);
  			}
  		}
-@@ -6502,6 +6503,8 @@
+@@ -6496,6 +6543,8 @@
  	char tmpid[256];
  	int forwardsallowed = 1;
  	int block_connected_line = 0;
-+        int nummems = 0;
-+        int numnoans = 0;
++	int nummems = 0;
++	int numnoans = 0;
  	struct ao2_iterator memi;
  	struct queue_end_bridge *queue_end_bridge = NULL;
  	int callcompletedinsl;
-@@ -6510,6 +6559,8 @@ static int try_calling(struct queue_ent *qe, struct ast_flags opts, char **opt_a
+@@ -6616,6 +6665,8 @@
  			/* Put them in the list of outgoing thingies...  We're ready now.
  			   XXX If we're forcibly removed, these outgoing calls won't get
  			   hung up XXX */
@@ -148,7 +138,7 @@ index 939a0e2..8fbd8c7 100644
  			tmp->q_next = outgoing;
  			outgoing = tmp;
  			/* If this line is up, don't try anybody else */
-@@ -6542,6 +6593,21 @@ static int try_calling(struct queue_ent *qe, struct ast_flags opts, char **opt_a
+@@ -6648,6 +6699,21 @@
  	++qe->pending;
  	ao2_unlock(qe->parent);
  	ring_one(qe, outgoing, &numbusies);
@@ -169,8 +159,8 @@ index 939a0e2..8fbd8c7 100644
 +	}
  	lpeer = wait_for_answer(qe, outgoing, &to, &digit, numbusies,
  		ast_test_flag(&(bridge_config.features_caller), AST_FEATURE_DISCONNECT),
- 		forwardsallowed, ringing);
-@@ -6558,6 +6624,32 @@ static int try_calling(struct queue_ent *qe, struct ast_flags opts, char **opt_a
+ 		forwardsallowed);
+@@ -6664,6 +6730,32 @@
  	peer = lpeer ? lpeer->chan : NULL;
  	if (!peer) {
  		qe->pending = 0;
@@ -203,7 +193,7 @@ index 939a0e2..8fbd8c7 100644
  		if (to) {
  			/* Must gotten hung up */
  			res = -1;
-@@ -6589,6 +6681,16 @@ static int try_calling(struct queue_ent *qe, struct ast_flags opts, char **opt_a
+@@ -6696,6 +6788,16 @@
  		/* Increment the refcount for this member, since we're going to be using it for awhile in here. */
  		ao2_ref(member, 1);
  		hangupcalls(qe, outgoing, peer, qe->cancel_answered_elsewhere);
@@ -220,25 +210,25 @@ index 939a0e2..8fbd8c7 100644
  		outgoing = NULL;
  		if (announce || qe->parent->reportholdtime || qe->parent->memberdelay) {
  			int res2;
-@@ -7048,7 +7150,7 @@ static int add_to_queue(const char *queuename, const char *interface, const char
+@@ -7143,7 +7245,7 @@
  			member_add_to_queue(q, new_member);
  			queue_publish_member_blob(queue_member_added_type(), queue_member_blob_create(q, new_member));
-
+ 
 -			if (is_member_available(q, new_member)) {
 +			if (!(q->LazyMembers && new_member->lastnoanswer) && is_member_available(q, new_member)) {
  				ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE, "Queue:%s_avail", q->name);
  			}
-
-@@ -7133,7 +7235,7 @@ static void set_queue_member_pause(struct call_queue *q, struct member *mem, con
+ 
+@@ -7226,7 +7328,7 @@
  		dump_queue_members(q);
  	}
-
+ 
 -	if (is_member_available(q, mem)) {
 +	if (!(q->LazyMembers && mem->lastnoanswer) && is_member_available(q, mem)) {
  		ast_devstate_changed(AST_DEVICE_NOT_INUSE, AST_DEVSTATE_CACHABLE,
  			"Queue:%s_avail", q->name);
  	} else if (!num_available_members(q)) {
-@@ -8071,6 +8173,20 @@ stop:
+@@ -8168,6 +8270,20 @@
  		} else if (qe.valid_digits) {
  			ast_queue_log(args.queuename, ast_channel_uniqueid(chan), "NONE", "EXITWITHKEY",
  				"%s|%d|%d|%ld", qe.digits, qe.pos, qe.opos, (long) (time(NULL) - qe.start));
@@ -258,12 +248,5 @@ index 939a0e2..8fbd8c7 100644
 +			/* End Schmooze Update */
  		}
  	}
-
-@@ -10994,4 +11110,3 @@ AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "True Call Queueing",
- 		.load_pri = AST_MODPRI_DEVSTATE_CONSUMER,
- 		.nonoptreq = "res_monitor",
- 	       );
--
---
-2.8.1
-
+ 
+Only in asterisk-13.18.0.lazymembers/apps: app_queue.c.orig


### PR DESCRIPTION
- Add increase-max-stack patch from FreePBX. When many contexts are created, avoid error: "Maximum PBX stack exceeded"
- Removed unbuilt docs
- Update lazymember patch from FreePBX
https://github.com/NethServer/dev/issues/5524