### PR TITLE
spec: remove libtonezone dependency

### DIFF
--- a/asterisk18.spec
+++ b/asterisk18.spec
@@ -420,7 +420,6 @@ Modules for Asterisk that use cURL.
 Summary: Modules for Asterisk that use DAHDI
 Requires: %{name}-core = %{version}-%{release}
 Requires: dahdi-tools >= 2.0.0
-Requires: libtonezone
 Requires(pre): %{_sbindir}/usermod
 Provides: asterisk-zaptel = %{version}-%{release}
 Provides: asterisk13-dahdi = 13.38.3-2


### PR DESCRIPTION
Drop the dependency because dahdi-tools already requires it.
With this explicit requires, when asterisk and dahdi-tools are installed
in the same transaction, yum can raise a conflict if libtonezone rpm is
present inside the repo (eg. nethesis-updates).

This conflict has been raised by Asterisk 18, Asterisk 13 didn't require it:
```
repoquery -q --whatrequires libtonezone --enablerepo=nethserver-testing
asterisk18-dahdi-0:18.11.1-1.ns7.x86_64
asterisk18-dahdi-0:18.11.1-2.ns7.x86_64
asterisk18-dahdi-0:18.12.1-1.1.g7e7e001.ns7.x86_64
dahdi-tools-0:2.11.1-1.17.sng.x86_64
dahdi-tools-0:2.11.1-16.el7.x86_64
dahdi-tools-0:2.11.1-17.ns7.x86_64
dahdi-tools-devel-0:2.11.1-16.el7.x86_64
dahdi-tools-devel-0:2.11.1-17.ns7.x86_64
dahdi-tools-devel-0:2.11.1-18.x86_64
```

NethServer/dev#6669